### PR TITLE
Downgrade python in travis CI to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
- - "3.7-dev"
+ - "3.6"
 install:
  - pip install pipenv
  - script/bootstrap


### PR DESCRIPTION
I had already downgraded the version of Python to a stable release (3.6) everywhere except - it seems - in the TravisCI configuration.  This PR downgrades it there too.